### PR TITLE
remove duplicate call to network when confirming transaction stake

### DIFF
--- a/source/scenes/home/Send/Confirm.tsx
+++ b/source/scenes/home/Send/Confirm.tsx
@@ -134,8 +134,6 @@ const SendConfirm = ({ navigation }: ISendConfirm) => {
 
     try {
       if (isExternalRequest) {
-        await controller.wallet.account.confirmContractTempTx(activeAsset)
-
         const background = await browser.runtime.getBackgroundPage();
 
         const {windowId} = queryString.parse(window.location.search);


### PR DESCRIPTION
This change will remove duplicate transaction calls to the network when a user tries to stake.
This may be the issue causing error messages being shown to the user even though the transaction succeeded.

The first transaction succeeds, but the second one fails and the second one is what throws the error before everything is done. 