### PR TITLE
Fixed:

### DIFF
--- a/source/selectors/nftSelectors.ts
+++ b/source/selectors/nftSelectors.ts
@@ -1,0 +1,13 @@
+/// //////////////////////
+// Modules
+/// //////////////////////
+
+import { RootState } from 'state/store';
+
+
+/// //////////////////////
+// Selectors
+/// //////////////////////
+
+
+export const getNfts = (state: RootState) => state.nfts;

--- a/source/selectors/walletsSelectors.ts
+++ b/source/selectors/walletsSelectors.ts
@@ -9,13 +9,13 @@
 import { RootState } from 'state/store';
 import { createSelector } from 'reselect';
 import { KeyringNetwork, KeyringWalletState, KeyringAssetInfo } from '@stardust-collective/dag4-keyring';
-
+import { getNfts } from './nftSelectors';
 /// //////////////////////
 // Types
 /// //////////////////////
 
 import { IAccountDerived, IWalletState, AssetType, IAssetState, ActiveNetwork } from 'state/vault/types';
-
+import { INFTListState } from 'state/nfts/types';
 /// //////////////////////
 // Selectors
 /// //////////////////////
@@ -101,12 +101,14 @@ const selectActiveNetworkAssets = createSelector(
  * Returns NFT assets
  * NFTs are fetched for the active network only so no activeNetwork checks are needed
  */
-const selectNFTAssets = createSelector(getActiveWallet, (activeWallet: IWalletState): IAssetState[] => {
+const selectNFTAssets = createSelector(getActiveWallet, getNfts, (activeWallet: IWalletState, nfts: INFTListState[] , ): IAssetState[] => {
   if (!activeWallet?.assets) {
     return [];
   }
 
-  return activeWallet.assets.filter((asset: IAssetState) => asset.type === AssetType.ERC721);
+  return activeWallet.assets.filter((asset: IAssetState) => {
+    return asset.type === AssetType.ERC721 && nfts[asset.id as any];
+  });
 });
 
 const selectActiveNetworkAssetIds = createSelector(selectActiveNetworkAssets, (assets: IAssetState[]): string[] => {


### PR DESCRIPTION
The following scenarios would only occur when adding a wallet via a private key with associated NFTs
- Crash when attempting to click into manage wallet.
- Crash when switching wallets.
- Crash when adding an account via a private key with associated NFTs.