### PR TITLE
Added custom message signing with dag4.js

### DIFF
--- a/source/components/TextV3/TextV3.scss
+++ b/source/components/TextV3/TextV3.scss
@@ -43,6 +43,8 @@
   font-weight: $regular;
   font-size: 14px;
   line-height: 20px;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .captionStrong {

--- a/source/scenes/external/Layouts/CardLayout/index.tsx
+++ b/source/scenes/external/Layouts/CardLayout/index.tsx
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 // Components
 ///////////////////////////
 
-import TextV3 from 'components/TextV3';
+import TextV3, {TEXT_ALIGN_ENUM} from 'components/TextV3';
 import Button from 'components/Button';
 
 ///////////////////////////
@@ -33,6 +33,7 @@ type ICardLayoutProps = {
   stepLabel: string;
   originDescriptionLabel: string;
   headerLabel: string;
+  footerLabel?: string;
   captionLabel: string;
   negativeButtonLabel: string,
   onNegativeButtonClick: () => void,
@@ -52,6 +53,7 @@ const CardLayout: FC<ICardLayoutProps> = ({
   stepLabel,
   originDescriptionLabel,
   headerLabel,
+  footerLabel='Only connect with sites you trust.',
   captionLabel,
   negativeButtonLabel,
   onNegativeButtonClick,
@@ -105,8 +107,8 @@ const CardLayout: FC<ICardLayoutProps> = ({
               {children}
             </div>
             <div className={styles.cardFooter}>
-              <TextV3.Caption color={COLORS_ENUMS.BLACK}>
-                Only connect with sites you trust.
+              <TextV3.Caption color={COLORS_ENUMS.BLACK} align={TEXT_ALIGN_ENUM.CENTER}>
+                {footerLabel}
               </TextV3.Caption>
             </div>
           </div>

--- a/source/scenes/external/SignatureRequest/index.module.scss
+++ b/source/scenes/external/SignatureRequest/index.module.scss
@@ -1,165 +1,35 @@
 @import '~assets/styles/variables';
 
-.wrapper {
+.content {
   display: flex;
-  position: fixed;
-  justify-content: center;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 0;
-  background: $white;
-  overflow: auto;
+  flex-flow: column nowrap;
+  padding: 10px 15px;
+  row-gap: 15px;
 
-  .frame {
-    width: 100%;
-    height: 100%;
-    min-height: 600px;
-    display: flex;
-    flex-direction: column;
-    box-sizing: border-box;
-    position: relative;
-
-    section.heading {
-      padding-top: 20px;
-      display: flex;
-      background: $gray-light;
-      width: 100%;
-      height: 72px;
-      align-items: center;
-      justify-content: center;
-      font-weight: 500;
-      font-size: 24px;
-    }
-
-    .row {
-      color: $black;
-      display: flex;
-      flex-direction: row;
-      justify-content: space-between;
-      width: 100%;
-      font-size: 16px;
-      padding: 0 24px;
-      box-sizing: border-box;
-      font-weight: 500;
-    }
-
-    label {
+  section {
+    > label {
       color: $black;
       font-size: 16px;
-      width: 100%;
-      display: block;
       font-weight: 500;
-      text-align: center;
-      margin: 12px 0;
     }
 
-    section.message {
-      padding: 0px 24px;
-      display: flex;
+    > div {
       color: $gray-100;
       font-size: 14px;
+      font-weight: 500;
+    }
+
+    &.message > div {
       white-space: pre-wrap;
       word-break: break-word;
-      font-weight: 500;
-      flex-direction: column;
-      border-top: 1px solid $gray-light;
-      border-bottom: 1px solid $gray-light;
-
-      & > span {
-        font-size: 16px;
-        line-height: 24px;
-        color: $black;
-      }
-
-      & > div.content{
-        padding: 10px 0;
-      }
     }
 
-    section.domain{
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      grid-auto-rows: min-content;
+    &.metadata > div {
+      display: flex;
+      flex-flow: column nowrap;
 
-      padding: 0px 24px;
-      color: $black;
-      font-size: 16px;
-      font-weight: 500;
-      
-      border-top: 1px solid $gray-light;
-      border-bottom: 1px solid $gray-light;
-
-      & > span {
-        line-height: 24px;
-        color: $black;
-        grid-area: 1 / 1 / 2 / 3;
-      }
-
-      & > small{
-        line-height: 24px;
-        color: $gray-100;
-      }
-    }
-
-    section.metadata{
-      display: grid;
-      grid-template-columns: 1fr;
-      grid-auto-rows: min-content;
-
-      padding: 0px 24px;
-      color: $black;
-      font-size: 16px;
-      font-weight: 500;
-      
-      border-top: 1px solid $gray-light;
-      border-bottom: 1px solid $gray-light;
-
-      & > span {
-        line-height: 24px;
-        color: $black;
-        grid-area: 1 / 1 / 2 / 3;
-      }
-
-      & > small{
+      & > small {
         font-size: 12px;
-        color: $gray-100;
-      }
-    }
-
-    section.content {
-      display: flex;
-      flex-direction: column;
-      width: 100%;
-      padding: 24px;
-      box-sizing: border-box;
-
-      .row {
-        padding: 0;
-        margin-bottom: 8px;
-        color: $gray-100;
-      }
-    }
-
-    section.actions {
-      margin-top: 20px;
-      width: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 0 36px;
-      padding-bottom: 20px;
-      box-sizing: border-box;
-
-      .close,
-      .close:hover {
-        background: $gray-light;
-        color: $gray-dark;
-      }
-
-      .button {
-        width: 144px;
       }
     }
   }

--- a/source/scenes/external/SignatureRequest/index.module.scss
+++ b/source/scenes/external/SignatureRequest/index.module.scss
@@ -10,6 +10,7 @@
   bottom: 0;
   z-index: 0;
   background: $white;
+  overflow: auto;
 
   .frame {
     width: 100%;
@@ -21,6 +22,7 @@
     position: relative;
 
     section.heading {
+      padding-top: 20px;
       display: flex;
       background: $gray-light;
       width: 100%;
@@ -57,16 +59,22 @@
       padding: 0px 24px;
       display: flex;
       color: $gray-100;
-      font-size: 16px;
-      line-height: 42px;
+      font-size: 14px;
+      white-space: pre-wrap;
+      word-break: break-word;
       font-weight: 500;
       flex-direction: column;
       border-top: 1px solid $gray-light;
       border-bottom: 1px solid $gray-light;
 
       & > span {
+        font-size: 16px;
         line-height: 24px;
         color: $black;
+      }
+
+      & > div.content{
+        padding: 10px 0;
       }
     }
 
@@ -78,7 +86,6 @@
       padding: 0px 24px;
       color: $black;
       font-size: 16px;
-      line-height: 42px;
       font-weight: 500;
       
       border-top: 1px solid $gray-light;
@@ -104,7 +111,6 @@
       padding: 0px 24px;
       color: $black;
       font-size: 16px;
-      line-height: 42px;
       font-weight: 500;
       
       border-top: 1px solid $gray-light;
@@ -117,7 +123,7 @@
       }
 
       & > small{
-        line-height: 24px;
+        font-size: 12px;
         color: $gray-100;
       }
     }
@@ -137,13 +143,13 @@
     }
 
     section.actions {
+      margin-top: 20px;
       width: 100%;
       display: flex;
       align-items: center;
       justify-content: space-between;
       padding: 0 36px;
-      bottom: 56px;
-      position: absolute;
+      padding-bottom: 20px;
       box-sizing: border-box;
 
       .close,

--- a/source/scenes/external/SignatureRequest/index.module.scss
+++ b/source/scenes/external/SignatureRequest/index.module.scss
@@ -44,20 +44,19 @@
     }
 
     label {
-      color: $gray-100;
+      color: $black;
       font-size: 16px;
       width: 100%;
       display: block;
       font-weight: 500;
       text-align: center;
       margin: 12px 0;
-      margin-top: 60px;
     }
 
     section.message {
-      padding: 12px 24px;
+      padding: 0px 24px;
       display: flex;
-      color: $black;
+      color: $gray-100;
       font-size: 16px;
       line-height: 42px;
       font-weight: 500;
@@ -66,6 +65,58 @@
       border-bottom: 1px solid $gray-light;
 
       & > span {
+        line-height: 24px;
+        color: $black;
+      }
+    }
+
+    section.domain{
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-auto-rows: min-content;
+
+      padding: 0px 24px;
+      color: $black;
+      font-size: 16px;
+      line-height: 42px;
+      font-weight: 500;
+      
+      border-top: 1px solid $gray-light;
+      border-bottom: 1px solid $gray-light;
+
+      & > span {
+        line-height: 24px;
+        color: $black;
+        grid-area: 1 / 1 / 2 / 3;
+      }
+
+      & > small{
+        line-height: 24px;
+        color: $gray-100;
+      }
+    }
+
+    section.metadata{
+      display: grid;
+      grid-template-columns: 1fr;
+      grid-auto-rows: min-content;
+
+      padding: 0px 24px;
+      color: $black;
+      font-size: 16px;
+      line-height: 42px;
+      font-weight: 500;
+      
+      border-top: 1px solid $gray-light;
+      border-bottom: 1px solid $gray-light;
+
+      & > span {
+        line-height: 24px;
+        color: $black;
+        grid-area: 1 / 1 / 2 / 3;
+      }
+
+      & > small{
         line-height: 24px;
         color: $gray-100;
       }

--- a/source/scenes/external/SignatureRequest/index.tsx
+++ b/source/scenes/external/SignatureRequest/index.tsx
@@ -1,4 +1,5 @@
 import styles from './index.module.scss';
+import queryString from 'query-string';
 import React, { useEffect } from 'react';
 import clsx from 'clsx';
 import Button from 'components/Button';
@@ -8,21 +9,28 @@ import { AssetType } from '../../../state/vault/types';
 
 const SignatureRequest = () => {
   const controller = useController();
-  const params = controller.dapp.getSigRequest();
+  const { windowId, data: stringData } = queryString.parse(location.search);
+  const params = JSON.parse(stringData as string);
   const account = controller.stargazerProvider.getAssetByType(AssetType.Constellation);
   const balance = controller.stargazerProvider.getBalance();
 
 
-  const handleCancel = () => {
+  const handleCancel = async () => {
+    const background = await browser.runtime.getBackgroundPage();
+    background.dispatchEvent(
+      new CustomEvent('messageSigned', { detail: { windowId, result: false } })
+    );
     window.close();
   };
 
-  useEffect(() => {}, []);
+  useEffect(() => { }, []);
 
   const handleSign = async () => {
+    const signature = controller.stargazerProvider.signMessage(params.message);
+
     const background = await browser.runtime.getBackgroundPage();
     background.dispatchEvent(
-      new CustomEvent('sign', { detail: window.location.hash })
+      new CustomEvent('messageSigned', { detail: { windowId, result: true, signature } })
     );
     window.close();
   };

--- a/source/scenes/external/SignatureRequest/index.tsx
+++ b/source/scenes/external/SignatureRequest/index.tsx
@@ -1,15 +1,18 @@
 import styles from './index.module.scss';
 import queryString from 'query-string';
 import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import clsx from 'clsx';
 import Button from 'components/Button';
 import { browser } from 'webextension-polyfill-ts';
 import { useController } from 'hooks/index';
 import { AssetType } from '../../../state/vault/types';
 import { ConstellationSignatureRequest } from '../../../scripts/Provider/StargazerProvider';
+import walletsSelectors from 'selectors/walletsSelectors'
 
 const SignatureRequest = () => {
   const controller = useController();
+  const wallets = useSelector(walletsSelectors.selectAllAccounts);
   const { windowId, data: stringData } = queryString.parse(location.search);
   const { origin, signatureRequest }:
     { origin: string, signatureRequest: ConstellationSignatureRequest } = JSON.parse(stringData as string);
@@ -34,10 +37,12 @@ const SignatureRequest = () => {
     const background = await browser.runtime.getBackgroundPage();
     background.dispatchEvent(
       new CustomEvent('messageSigned', {
-        detail: { windowId, result: true, signature: {
-          hex: signature,
-          requestEncoded: signatureRequestEncoded
-        }}
+        detail: {
+          windowId, result: true, signature: {
+            hex: signature,
+            requestEncoded: signatureRequestEncoded
+          }
+        }
       })
     );
     window.close();
@@ -53,7 +58,7 @@ const SignatureRequest = () => {
             <span>Balance:</span>
           </div>
           <div className={styles.row}>
-            <span>{account.label}</span>
+            <span>{wallets.find(w => w.address === account.address)?.label ?? account.address}</span>
             <span>{balance} DAG</span>
           </div>
         </section>

--- a/source/scenes/external/SignatureRequest/index.tsx
+++ b/source/scenes/external/SignatureRequest/index.tsx
@@ -66,23 +66,16 @@ const SignatureRequest = () => {
           <span>{origin}</span>
         </div>
         <label>You are signing:</label>
-        <section className={styles.domain}>
-          <span>Domain Details:</span>
-          <small>ChainId: {signatureRequest.domain.chainId}</small>
-          <small>Name: {signatureRequest.domain.name}</small>
-          <small>Uri: {signatureRequest.domain.uri}</small>
-          <small>Version: {signatureRequest.domain.version}</small>
-        </section>
         <section className={styles.message}>
           <span>Message:</span>
           <div className={styles.content}>
-            {signatureRequest.message.content}
+            {signatureRequest.content}
           </div>
         </section>
-        {Object.keys(signatureRequest.message.metadata).length > 0 && <>
+        {Object.keys(signatureRequest.metadata).length > 0 && <>
           <label>With metadata:</label>
           <section className={styles.metadata}>
-            {Object.entries(signatureRequest.message.metadata).map(
+            {Object.entries(signatureRequest.metadata).map(
               ([key, value]) => (<small>{key} = {value}</small>)
             )}
           </section>

--- a/source/scenes/external/SignatureRequest/index.tsx
+++ b/source/scenes/external/SignatureRequest/index.tsx
@@ -7,18 +7,18 @@ import Button from 'components/Button';
 import { browser } from 'webextension-polyfill-ts';
 import { useController } from 'hooks/index';
 import { AssetType } from '../../../state/vault/types';
-import { ConstellationSignatureRequest } from '../../../scripts/Provider/StargazerProvider';
 import walletsSelectors from 'selectors/walletsSelectors'
 
 const SignatureRequest = () => {
   const controller = useController();
   const wallets = useSelector(walletsSelectors.selectAllAccounts);
   const { windowId, data: stringData } = queryString.parse(location.search);
-  const { origin, signatureRequest }:
-    { origin: string, signatureRequest: ConstellationSignatureRequest } = JSON.parse(stringData as string);
+  const { origin, signatureRequestEncoded }:
+    { origin: string, signatureRequestEncoded: string } = JSON.parse(stringData as string);
   const account = controller.stargazerProvider.getAssetByType(AssetType.Constellation);
   const balance = controller.stargazerProvider.getBalance();
 
+  const signatureRequest = JSON.parse(window.atob(signatureRequestEncoded));
 
   const handleCancel = async () => {
     const background = await browser.runtime.getBackgroundPage();
@@ -31,7 +31,6 @@ const SignatureRequest = () => {
   useEffect(() => { }, []);
 
   const handleSign = async () => {
-    const signatureRequestEncoded = window.btoa(JSON.stringify(signatureRequest));
     const signature = controller.stargazerProvider.signMessage(signatureRequestEncoded);
 
     const background = await browser.runtime.getBackgroundPage();
@@ -76,7 +75,9 @@ const SignatureRequest = () => {
         </section>
         <section className={styles.message}>
           <span>Message:</span>
-          {signatureRequest.message.content}
+          <div className={styles.content}>
+            {signatureRequest.message.content}
+          </div>
         </section>
         {Object.keys(signatureRequest.message.metadata).length > 0 && <>
           <label>With metadata:</label>

--- a/source/scripts/Background/controllers/MessageHandler/index.ts
+++ b/source/scripts/Background/controllers/MessageHandler/index.ts
@@ -74,8 +74,7 @@ export const messagesHandler = (
                     masterController,
                     message,
                     origin,
-                    setPendingWindow,
-                    isPendingWindow
+                    setPendingWindow
                 );
             default:
                 return Promise.resolve(null);

--- a/source/scripts/Background/controllers/MessageHandler/requests.ts
+++ b/source/scripts/Background/controllers/MessageHandler/requests.ts
@@ -59,9 +59,9 @@ export const handleRequest = async (
                 }));
             }
             
-            let signatureRequest: ConstellationSignatureRequest;
+            let signatureRequestEncoded: string;
             try{
-                signatureRequest = masterController.stargazerProvider.parseSignatureRequest(args[0]);
+                signatureRequestEncoded = masterController.stargazerProvider.normalizeSignatureRequest(args[0]);
             }catch(e){
                 return Promise.reject(new CustomEvent(message.id, {
                     detail: e instanceof Error ? e.message : 'signMessage-error'
@@ -70,7 +70,7 @@ export const handleRequest = async (
         
             const data = {
                 origin,
-                signatureRequest,
+                signatureRequestEncoded,
             }
 
             const popup = await masterController.createPopup(

--- a/source/scripts/Background/controllers/MessageHandler/types.ts
+++ b/source/scripts/Background/controllers/MessageHandler/types.ts
@@ -31,7 +31,8 @@ export enum SUPPORTED_WALLET_METHODS {
     isConnected,
     getNetwork,
     getAddress,
-    getBalance
+    getBalance,
+    getPublicKey
 }
 
 export const SUPPORTED_CHAINS = [

--- a/source/scripts/ContentScript/inject/stargazerProvider.txt.ts
+++ b/source/scripts/ContentScript/inject/stargazerProvider.txt.ts
@@ -15,7 +15,9 @@ const REQUEST_MAP = {
     chainId: SUPPORTED_WALLET_METHODS.getChainId,
     accounts: SUPPORTED_WALLET_METHODS.getAccounts,
     sendTransaction: SUPPORTED_WALLET_METHODS.sendTransaction,
-    getBalance: SUPPORTED_WALLET_METHODS.getBalance
+    getBalance: SUPPORTED_WALLET_METHODS.getBalance,
+    getPublicKey: SUPPORTED_WALLET_METHODS.getPublicKey,
+    signMessage: SUPPORTED_WALLET_METHODS.signMessage
   },
   isConnected: SUPPORTED_WALLET_METHODS.isConnected,
   getNetwork: SUPPORTED_WALLET_METHODS.getNetwork,

--- a/source/scripts/ContentScript/inject/stargazerProvider.txt.ts
+++ b/source/scripts/ContentScript/inject/stargazerProvider.txt.ts
@@ -8,7 +8,8 @@ const REQUEST_MAP = {
     accounts: SUPPORTED_WALLET_METHODS.getAccounts,
     blockNumber: SUPPORTED_WALLET_METHODS.getBlockNumber,
     estimateGas: SUPPORTED_WALLET_METHODS.estimateGas,
-    sendTransaction: SUPPORTED_WALLET_METHODS.sendTransaction
+    sendTransaction: SUPPORTED_WALLET_METHODS.sendTransaction,
+    signMessage: SUPPORTED_WALLET_METHODS.signMessage,
   },
   DAG: {
     chainId: SUPPORTED_WALLET_METHODS.getChainId,
@@ -56,6 +57,10 @@ async function handleRequest(chain, req) {
   const asset = SUPPORTED_CHAINS[chain].asset;
 
   const provider = window.providerManager.getProviderFor(asset);
+
+  if(req.method === 'personal_sign'){
+    req.method = `eth_signMessage`;
+  }
 
   let [prefix, method] = req.method.split('_');
 

--- a/source/scripts/ContentScript/inject/stargazerProvider.txt.ts
+++ b/source/scripts/ContentScript/inject/stargazerProvider.txt.ts
@@ -8,8 +8,7 @@ const REQUEST_MAP = {
     accounts: SUPPORTED_WALLET_METHODS.getAccounts,
     blockNumber: SUPPORTED_WALLET_METHODS.getBlockNumber,
     estimateGas: SUPPORTED_WALLET_METHODS.estimateGas,
-    sendTransaction: SUPPORTED_WALLET_METHODS.sendTransaction,
-    signMessage: SUPPORTED_WALLET_METHODS.signMessage
+    sendTransaction: SUPPORTED_WALLET_METHODS.sendTransaction
   },
   DAG: {
     chainId: SUPPORTED_WALLET_METHODS.getChainId,

--- a/source/scripts/Provider/EthereumProvider.ts
+++ b/source/scripts/Provider/EthereumProvider.ts
@@ -1,5 +1,4 @@
 import store from 'state/store';
-import { dag4 } from '@stardust-collective/dag4';
 import { ecsign, hashPersonalMessage, toRpcSig } from 'ethereumjs-util';
 import find from 'lodash/find';
 import IVaultState, { AssetType, IAssetState } from '../../state/vault/types';
@@ -7,9 +6,10 @@ import { IDAppState } from '../../state/dapp/types';
 import { useController } from 'hooks/index';
 import { KeyringNetwork } from '@stardust-collective/dag4-keyring';
 import { estimateGasPrice } from 'utils/ethUtil';
+import { StargazerSignatureRequest } from './StargazerProvider';
 
 export class EthereumProvider {
-  constructor() { }
+  constructor() {}
 
   getNetwork() {
     const { activeNetwork }: IVaultState = store.getState().vault;
@@ -57,11 +57,10 @@ export class EthereumProvider {
 
     const ethAddresses = dappData.accounts.Ethereum;
     const activeAddress = find(activeWallet.assets, { id: 'ethereum' });
-  
-    return [
-      activeAddress?.address,
-      ...ethAddresses.filter( address => address !== activeAddress?.address)
-    ].filter(Boolean);  // if no active address, remove
+
+    return [activeAddress?.address, ...ethAddresses.filter((address) => address !== activeAddress?.address)].filter(
+      Boolean
+    ); // if no active address, remove
   }
 
   getBlockNumber() {
@@ -80,13 +79,52 @@ export class EthereumProvider {
     return stargazerAsset && balances[AssetType.Ethereum];
   }
 
+  normalizeSignatureRequest(encodedSignatureRequest: string): string {
+    let signatureRequest: StargazerSignatureRequest;
+    try {
+      signatureRequest = JSON.parse(window.atob(encodedSignatureRequest));
+    } catch (e) {
+      throw new Error('Unable to decode signatureRequest');
+    }
+
+    const test =
+      typeof signatureRequest === 'object' &&
+      signatureRequest !== null &&
+      typeof signatureRequest.content === 'string' &&
+      typeof signatureRequest.metadata === 'object' &&
+      signatureRequest.metadata !== null;
+
+    if (!test) {
+      throw new Error('SignatureRequest does not match spec');
+    }
+
+    let parsedMetadata: Record<string, any> = {};
+    for (const [key, value] of Object.entries(signatureRequest.metadata)) {
+      if (['boolean', 'number', 'string'].includes(typeof value) || value === null) {
+        parsedMetadata[key] = value;
+      }
+    }
+
+    signatureRequest.metadata = parsedMetadata;
+
+    const newEncodedSignatureRequest = window.btoa(JSON.stringify(signatureRequest));
+
+    if(newEncodedSignatureRequest !== encodedSignatureRequest){
+      throw new Error('SignatureRequest does not match spec (unable to re-normalize)');
+    }
+
+    return newEncodedSignatureRequest;
+  }
+
   signMessage(msg: string) {
-    const privateKeyHex = dag4.account.keyTrio.privateKey;
+    const controller = useController();
+    const wallet = controller.wallet.account.ethClient.getWallet();
+    const privateKeyHex = this.remove0x(wallet.privateKey);
     const privateKey = Buffer.from(privateKeyHex, 'hex');
     const msgHash = hashPersonalMessage(Buffer.from(msg));
 
     const { v, r, s } = ecsign(msgHash, privateKey);
-    const sig = this.remove0x(toRpcSig(v, r, s));
+    const sig = this.preserve0x(toRpcSig(v, r, s));
 
     return sig;
   }
@@ -97,10 +135,10 @@ export class EthereumProvider {
     let stargazerAsset: IAssetState = activeAsset as IAssetState;
 
     if (!activeAsset || activeAsset.type !== type) {
-      stargazerAsset = activeWallet.assets.find(a => a.type === type);
+      stargazerAsset = activeWallet.assets.find((a) => a.type === type);
     }
 
-    return stargazerAsset
+    return stargazerAsset;
   }
 
   /*
@@ -152,6 +190,10 @@ export class EthereumProvider {
 
   private remove0x(hash: string) {
     return hash.startsWith('0x') ? hash.slice(2) : hash;
+  }
+
+  private preserve0x(hash: string) {
+    return hash.startsWith('0x') ? hash : '0x' + hash;
   }
 }
 

--- a/source/scripts/Provider/StargazerProvider.ts
+++ b/source/scripts/Provider/StargazerProvider.ts
@@ -122,7 +122,7 @@ export class StargazerProvider {
     return stargazerAsset && balances[AssetType.Constellation];
   }
 
-  parseSignatureRequest(encodedSignatureRequest: string): ConstellationSignatureRequest{
+  normalizeSignatureRequest(encodedSignatureRequest: string): string{
     let signatureRequest: ConstellationSignatureRequest;
     try{
         signatureRequest = JSON.parse(window.atob(encodedSignatureRequest));
@@ -154,7 +154,7 @@ export class StargazerProvider {
 
     signatureRequest.message.metadata = parsedMetadata;
 
-    return signatureRequest;
+    return window.btoa(JSON.stringify(signatureRequest));
   }
 
   signMessage(msg: string) {

--- a/source/web/pages/External/App.tsx
+++ b/source/web/pages/External/App.tsx
@@ -7,6 +7,7 @@ import SelectAccounts from 'scenes/external/SelectAccounts';
 import ApproveSpend from 'scenes/external/ApproveSpend';
 import SendTransaction from 'scenes/home/Send/Send';
 import ConfirmTransaction from 'scenes/home/Send/Confirm';
+import SignatureRequest from 'scenes/external/SignatureRequest'
 
 import 'assets/styles/global.scss';
 import { useController } from 'hooks/index';
@@ -28,6 +29,7 @@ const App: FC = () => {
             <Route path="/approveSpend" component={ApproveSpend} />
             <Route path="/sendTransaction" component={SendTransaction} />
             <Route path="/confirmTransaction" component={ConfirmTransaction} />
+            <Route path="/signMessage" component={SignatureRequest} />
             <Route path="/">
               {!isUnlocked ?
                 <Redirect to={`/login${location.search}`} /> :


### PR DESCRIPTION
### Changes

+ Restored the `SignatureRequest` external screen.
+ Refactored the `SUPPORTED_WALLET_METHODS.signMessage` method to use dag4.js, only available in `chain:constellation`.
+ Added the `SUPPORTED_WALLET_METHODS.getPublicKey` method, only available in `chain:constellation`.

### Signature Request

Signature requests under the RPC method `dag_signMessage` receive a single Base64 Encoded JSON object with the following properties:
```typescript
type ConstellationSignatureRequest = {
  domain: {
    chainId: number;
    name: string;
    uri: string;
    version: string;
  },
  message:{
    content: string,
    metadata: Record<string, any>
  }
}
```
if any of those properties are invalid the method rejects, the `message.metadata` property should not contain nested objects.
if the user accepts the request, this method signs the `SignedMessage.requestEncoded` property returns the following object:
```typescript
type SignedMessage = {
  hex: string; // The hex signature from the dag4.js lib
  requestEncoded: string; // Base 64 Encoded JSON request (strips out nested metadata objects)
}
```

### Get Public Key

It's possible now to obtain a DAG wallet public key using the RPC method `dag_getPublicKey`, this method will return an object with a `publicKey` property if the current site is whitelisted otherwise this property is undefined.

https://github.com/StardustCollective/Lattice/pull/136
https://github.com/StardustCollective/lattice-api/pull/42