### PR TITLE
Added personal message signing with eth provider

### DIFF
--- a/source/components/TextV3/TextV3.scss
+++ b/source/components/TextV3/TextV3.scss
@@ -43,6 +43,8 @@
   font-weight: $regular;
   font-size: 14px;
   line-height: 20px;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .captionStrong {

--- a/source/scenes/external/Layouts/CardLayout/index.tsx
+++ b/source/scenes/external/Layouts/CardLayout/index.tsx
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 // Components
 ///////////////////////////
 
-import TextV3 from 'components/TextV3';
+import TextV3, {TEXT_ALIGN_ENUM} from 'components/TextV3';
 import Button from 'components/Button';
 
 ///////////////////////////
@@ -33,6 +33,7 @@ type ICardLayoutProps = {
   stepLabel: string;
   originDescriptionLabel: string;
   headerLabel: string;
+  footerLabel?: string;
   captionLabel: string;
   negativeButtonLabel: string,
   onNegativeButtonClick: () => void,
@@ -52,6 +53,7 @@ const CardLayout: FC<ICardLayoutProps> = ({
   stepLabel,
   originDescriptionLabel,
   headerLabel,
+  footerLabel='Only connect with sites you trust.',
   captionLabel,
   negativeButtonLabel,
   onNegativeButtonClick,
@@ -105,8 +107,8 @@ const CardLayout: FC<ICardLayoutProps> = ({
               {children}
             </div>
             <div className={styles.cardFooter}>
-              <TextV3.Caption color={COLORS_ENUMS.BLACK}>
-                Only connect with sites you trust.
+              <TextV3.Caption color={COLORS_ENUMS.BLACK} align={TEXT_ALIGN_ENUM.CENTER}>
+                {footerLabel}
               </TextV3.Caption>
             </div>
           </div>

--- a/source/scenes/external/SignatureRequest/index.module.scss
+++ b/source/scenes/external/SignatureRequest/index.module.scss
@@ -1,165 +1,35 @@
 @import '~assets/styles/variables';
 
-.wrapper {
+.content {
   display: flex;
-  position: fixed;
-  justify-content: center;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 0;
-  background: $white;
-  overflow: auto;
+  flex-flow: column nowrap;
+  padding: 10px 15px;
+  row-gap: 15px;
 
-  .frame {
-    width: 100%;
-    height: 100%;
-    min-height: 600px;
-    display: flex;
-    flex-direction: column;
-    box-sizing: border-box;
-    position: relative;
-
-    section.heading {
-      padding-top: 20px;
-      display: flex;
-      background: $gray-light;
-      width: 100%;
-      height: 72px;
-      align-items: center;
-      justify-content: center;
-      font-weight: 500;
-      font-size: 24px;
-    }
-
-    .row {
-      color: $black;
-      display: flex;
-      flex-direction: row;
-      justify-content: space-between;
-      width: 100%;
-      font-size: 16px;
-      padding: 0 24px;
-      box-sizing: border-box;
-      font-weight: 500;
-    }
-
-    label {
+  section {
+    > label {
       color: $black;
       font-size: 16px;
-      width: 100%;
-      display: block;
       font-weight: 500;
-      text-align: center;
-      margin: 12px 0;
     }
 
-    section.message {
-      padding: 0px 24px;
-      display: flex;
+    > div {
       color: $gray-100;
       font-size: 14px;
+      font-weight: 500;
+    }
+
+    &.message > div {
       white-space: pre-wrap;
       word-break: break-word;
-      font-weight: 500;
-      flex-direction: column;
-      border-top: 1px solid $gray-light;
-      border-bottom: 1px solid $gray-light;
-
-      & > span {
-        font-size: 16px;
-        line-height: 24px;
-        color: $black;
-      }
-
-      & > div.content{
-        padding: 10px 0;
-      }
     }
 
-    section.domain{
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      grid-auto-rows: min-content;
+    &.metadata > div {
+      display: flex;
+      flex-flow: column nowrap;
 
-      padding: 0px 24px;
-      color: $black;
-      font-size: 16px;
-      font-weight: 500;
-      
-      border-top: 1px solid $gray-light;
-      border-bottom: 1px solid $gray-light;
-
-      & > span {
-        line-height: 24px;
-        color: $black;
-        grid-area: 1 / 1 / 2 / 3;
-      }
-
-      & > small{
-        line-height: 24px;
-        color: $gray-100;
-      }
-    }
-
-    section.metadata{
-      display: grid;
-      grid-template-columns: 1fr;
-      grid-auto-rows: min-content;
-
-      padding: 0px 24px;
-      color: $black;
-      font-size: 16px;
-      font-weight: 500;
-      
-      border-top: 1px solid $gray-light;
-      border-bottom: 1px solid $gray-light;
-
-      & > span {
-        line-height: 24px;
-        color: $black;
-        grid-area: 1 / 1 / 2 / 3;
-      }
-
-      & > small{
+      & > small {
         font-size: 12px;
-        color: $gray-100;
-      }
-    }
-
-    section.content {
-      display: flex;
-      flex-direction: column;
-      width: 100%;
-      padding: 24px;
-      box-sizing: border-box;
-
-      .row {
-        padding: 0;
-        margin-bottom: 8px;
-        color: $gray-100;
-      }
-    }
-
-    section.actions {
-      margin-top: 20px;
-      width: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 0 36px;
-      padding-bottom: 20px;
-      box-sizing: border-box;
-
-      .close,
-      .close:hover {
-        background: $gray-light;
-        color: $gray-dark;
-      }
-
-      .button {
-        width: 144px;
       }
     }
   }

--- a/source/scripts/Background/controllers/MessageHandler/index.ts
+++ b/source/scripts/Background/controllers/MessageHandler/index.ts
@@ -74,8 +74,7 @@ export const messagesHandler = (
                     masterController,
                     message,
                     origin,
-                    setPendingWindow,
-                    isPendingWindow
+                    setPendingWindow
                 );
             default:
                 return Promise.resolve(null);

--- a/source/scripts/ContentScript/inject/stargazerProvider.txt.ts
+++ b/source/scripts/ContentScript/inject/stargazerProvider.txt.ts
@@ -8,7 +8,8 @@ const REQUEST_MAP = {
     accounts: SUPPORTED_WALLET_METHODS.getAccounts,
     blockNumber: SUPPORTED_WALLET_METHODS.getBlockNumber,
     estimateGas: SUPPORTED_WALLET_METHODS.estimateGas,
-    sendTransaction: SUPPORTED_WALLET_METHODS.sendTransaction
+    sendTransaction: SUPPORTED_WALLET_METHODS.sendTransaction,
+    signMessage: SUPPORTED_WALLET_METHODS.signMessage,
   },
   DAG: {
     chainId: SUPPORTED_WALLET_METHODS.getChainId,
@@ -56,6 +57,10 @@ async function handleRequest(chain, req) {
   const asset = SUPPORTED_CHAINS[chain].asset;
 
   const provider = window.providerManager.getProviderFor(asset);
+
+  if(req.method === 'personal_sign'){
+    req.method = `eth_signMessage`;
+  }
 
   let [prefix, method] = req.method.split('_');
 

--- a/source/scripts/Provider/EthereumProvider.ts
+++ b/source/scripts/Provider/EthereumProvider.ts
@@ -1,5 +1,4 @@
 import store from 'state/store';
-import { dag4 } from '@stardust-collective/dag4';
 import { ecsign, hashPersonalMessage, toRpcSig } from 'ethereumjs-util';
 import find from 'lodash/find';
 import IVaultState, { AssetType, IAssetState } from '../../state/vault/types';
@@ -7,6 +6,7 @@ import { IDAppState } from '../../state/dapp/types';
 import { useController } from 'hooks/index';
 import { KeyringNetwork } from '@stardust-collective/dag4-keyring';
 import { estimateGasPrice } from 'utils/ethUtil';
+import { StargazerSignatureRequest } from './StargazerProvider';
 
 export class EthereumProvider {
   constructor() { }
@@ -80,13 +80,44 @@ export class EthereumProvider {
     return stargazerAsset && balances[AssetType.Ethereum];
   }
 
+  normalizeSignatureRequest(encodedSignatureRequest: string): string{
+    let signatureRequest: StargazerSignatureRequest;
+    try{
+        signatureRequest = JSON.parse(window.atob(encodedSignatureRequest));
+    }catch(e){
+        throw new Error('Unable to decode signatureRequest');
+    }
+
+    let test = true;
+    test = test && typeof signatureRequest === 'object' && signatureRequest !== null;
+    test = test && typeof signatureRequest.content === 'string';
+    test = test && typeof signatureRequest.metadata === 'object' && signatureRequest.metadata !== null;
+
+    if(!test){
+      throw new Error('SignatureRequest does not match spec');
+    }
+
+    let parsedMetadata: Record<string, any> = {};
+    for(const [key, value] of Object.entries(signatureRequest.metadata)){
+      if(["boolean", "number", "string"].includes(typeof value) || value === null){
+        parsedMetadata[key] = value;
+      }
+    }
+
+    signatureRequest.metadata = parsedMetadata;
+
+    return window.btoa(JSON.stringify(signatureRequest));
+  }
+
   signMessage(msg: string) {
-    const privateKeyHex = dag4.account.keyTrio.privateKey;
+    const controller = useController();
+    const wallet = controller.wallet.account.ethClient.getWallet();
+    const privateKeyHex = this.remove0x(wallet.privateKey);
     const privateKey = Buffer.from(privateKeyHex, 'hex');
     const msgHash = hashPersonalMessage(Buffer.from(msg));
 
     const { v, r, s } = ecsign(msgHash, privateKey);
-    const sig = this.remove0x(toRpcSig(v, r, s));
+    const sig = this.preserve0x(toRpcSig(v, r, s));
 
     return sig;
   }
@@ -152,6 +183,10 @@ export class EthereumProvider {
 
   private remove0x(hash: string) {
     return hash.startsWith('0x') ? hash.slice(2) : hash;
+  }
+
+  private preserve0x(hash: string) {
+    return hash.startsWith('0x') ? hash : '0x' + hash;
   }
 }
 

--- a/source/scripts/Provider/EthereumProvider.ts
+++ b/source/scripts/Provider/EthereumProvider.ts
@@ -9,7 +9,7 @@ import { estimateGasPrice } from 'utils/ethUtil';
 import { StargazerSignatureRequest } from './StargazerProvider';
 
 export class EthereumProvider {
-  constructor() { }
+  constructor() {}
 
   getNetwork() {
     const { activeNetwork }: IVaultState = store.getState().vault;
@@ -57,11 +57,10 @@ export class EthereumProvider {
 
     const ethAddresses = dappData.accounts.Ethereum;
     const activeAddress = find(activeWallet.assets, { id: 'ethereum' });
-  
-    return [
-      activeAddress?.address,
-      ...ethAddresses.filter( address => address !== activeAddress?.address)
-    ].filter(Boolean);  // if no active address, remove
+
+    return [activeAddress?.address, ...ethAddresses.filter((address) => address !== activeAddress?.address)].filter(
+      Boolean
+    ); // if no active address, remove
   }
 
   getBlockNumber() {
@@ -80,12 +79,12 @@ export class EthereumProvider {
     return stargazerAsset && balances[AssetType.Ethereum];
   }
 
-  normalizeSignatureRequest(encodedSignatureRequest: string): string{
+  normalizeSignatureRequest(encodedSignatureRequest: string): string {
     let signatureRequest: StargazerSignatureRequest;
-    try{
-        signatureRequest = JSON.parse(window.atob(encodedSignatureRequest));
-    }catch(e){
-        throw new Error('Unable to decode signatureRequest');
+    try {
+      signatureRequest = JSON.parse(window.atob(encodedSignatureRequest));
+    } catch (e) {
+      throw new Error('Unable to decode signatureRequest');
     }
 
     let test = true;
@@ -93,20 +92,26 @@ export class EthereumProvider {
     test = test && typeof signatureRequest.content === 'string';
     test = test && typeof signatureRequest.metadata === 'object' && signatureRequest.metadata !== null;
 
-    if(!test){
+    if (!test) {
       throw new Error('SignatureRequest does not match spec');
     }
 
     let parsedMetadata: Record<string, any> = {};
-    for(const [key, value] of Object.entries(signatureRequest.metadata)){
-      if(["boolean", "number", "string"].includes(typeof value) || value === null){
+    for (const [key, value] of Object.entries(signatureRequest.metadata)) {
+      if (['boolean', 'number', 'string'].includes(typeof value) || value === null) {
         parsedMetadata[key] = value;
       }
     }
 
     signatureRequest.metadata = parsedMetadata;
 
-    return window.btoa(JSON.stringify(signatureRequest));
+    const newEncodedSignatureRequest = window.btoa(JSON.stringify(signatureRequest));
+
+    if(newEncodedSignatureRequest !== encodedSignatureRequest){
+      throw new Error('SignatureRequest does not match spec (unable to re-normalize)');
+    }
+
+    return newEncodedSignatureRequest;
   }
 
   signMessage(msg: string) {
@@ -128,10 +133,10 @@ export class EthereumProvider {
     let stargazerAsset: IAssetState = activeAsset as IAssetState;
 
     if (!activeAsset || activeAsset.type !== type) {
-      stargazerAsset = activeWallet.assets.find(a => a.type === type);
+      stargazerAsset = activeWallet.assets.find((a) => a.type === type);
     }
 
-    return stargazerAsset
+    return stargazerAsset;
   }
 
   /*

--- a/source/scripts/Provider/EthereumProvider.ts
+++ b/source/scripts/Provider/EthereumProvider.ts
@@ -87,10 +87,12 @@ export class EthereumProvider {
       throw new Error('Unable to decode signatureRequest');
     }
 
-    let test = true;
-    test = test && typeof signatureRequest === 'object' && signatureRequest !== null;
-    test = test && typeof signatureRequest.content === 'string';
-    test = test && typeof signatureRequest.metadata === 'object' && signatureRequest.metadata !== null;
+    const test =
+      typeof signatureRequest === 'object' &&
+      signatureRequest !== null &&
+      typeof signatureRequest.content === 'string' &&
+      typeof signatureRequest.metadata === 'object' &&
+      signatureRequest.metadata !== null;
 
     if (!test) {
       throw new Error('SignatureRequest does not match spec');

--- a/source/scripts/Provider/StargazerProvider.ts
+++ b/source/scripts/Provider/StargazerProvider.ts
@@ -7,9 +7,9 @@ import { IDAppState } from '../../state/dapp/types';
 import { useController } from 'hooks/index';
 
 export type StargazerSignatureRequest = {
-  content: string,
-  metadata: Record<string, any>
-}
+  content: string;
+  metadata: Record<string, any>;
+};
 export class StargazerProvider {
   constructor() {}
 
@@ -32,7 +32,7 @@ export class StargazerProvider {
     return stargazerAsset && stargazerAsset.address;
   }
 
-  getPublicKey(){
+  getPublicKey() {
     const { dapp, vault } = store.getState();
     const { whitelist }: IDAppState = dapp;
 
@@ -113,26 +113,28 @@ export class StargazerProvider {
     return stargazerAsset && balances[AssetType.Constellation];
   }
 
-  normalizeSignatureRequest(encodedSignatureRequest: string): string{
+  normalizeSignatureRequest(encodedSignatureRequest: string): string {
     let signatureRequest: StargazerSignatureRequest;
-    try{
-        signatureRequest = JSON.parse(window.atob(encodedSignatureRequest));
-    }catch(e){
-        throw new Error('Unable to decode signatureRequest');
+    try {
+      signatureRequest = JSON.parse(window.atob(encodedSignatureRequest));
+    } catch (e) {
+      throw new Error('Unable to decode signatureRequest');
     }
 
-    let test = true;
-    test = test && typeof signatureRequest === 'object' && signatureRequest !== null;
-    test = test && typeof signatureRequest.content === 'string';
-    test = test && typeof signatureRequest.metadata === 'object' && signatureRequest.metadata !== null;
+    const test =
+      typeof signatureRequest === 'object' &&
+      signatureRequest !== null &&
+      typeof signatureRequest.content === 'string' &&
+      typeof signatureRequest.metadata === 'object' &&
+      signatureRequest.metadata !== null;
 
-    if(!test){
+    if (!test) {
       throw new Error('SignatureRequest does not match spec');
     }
 
     let parsedMetadata: Record<string, any> = {};
-    for(const [key, value] of Object.entries(signatureRequest.metadata)){
-      if(["boolean", "number", "string"].includes(typeof value) || value === null){
+    for (const [key, value] of Object.entries(signatureRequest.metadata)) {
+      if (['boolean', 'number', 'string'].includes(typeof value) || value === null) {
         parsedMetadata[key] = value;
       }
     }
@@ -141,7 +143,7 @@ export class StargazerProvider {
 
     const newEncodedSignatureRequest = window.btoa(JSON.stringify(signatureRequest));
 
-    if(newEncodedSignatureRequest !== encodedSignatureRequest){
+    if (newEncodedSignatureRequest !== encodedSignatureRequest) {
       throw new Error('SignatureRequest does not match spec (unable to re-normalize)');
     }
 

--- a/source/scripts/Provider/StargazerProvider.ts
+++ b/source/scripts/Provider/StargazerProvider.ts
@@ -6,11 +6,10 @@ import IVaultState, { AssetType, IAssetState } from '../../state/vault/types';
 import { IDAppState } from '../../state/dapp/types';
 import { useController } from 'hooks/index';
 
-export type ConstellationSignatureRequest = {
+export type StargazerSignatureRequest = {
   content: string,
   metadata: Record<string, any>
 }
-
 export class StargazerProvider {
   constructor() {}
 
@@ -115,7 +114,7 @@ export class StargazerProvider {
   }
 
   normalizeSignatureRequest(encodedSignatureRequest: string): string{
-    let signatureRequest: ConstellationSignatureRequest;
+    let signatureRequest: StargazerSignatureRequest;
     try{
         signatureRequest = JSON.parse(window.atob(encodedSignatureRequest));
     }catch(e){
@@ -148,12 +147,6 @@ export class StargazerProvider {
     const sig = dag4.keyStore.sign(privateKeyHex, msg);
 
     return sig;
-  }
-
-  verifyMessage(msg: string, sig: string) {
-    const publicKeyHex = dag4.account.keyTrio.publicKey;
-    const result = dag4.keyStore.verify(publicKeyHex, msg, sig);
-    return result;
   }
 
   getAssetByType(type: AssetType) {

--- a/source/scripts/Provider/StargazerProvider.ts
+++ b/source/scripts/Provider/StargazerProvider.ts
@@ -139,7 +139,13 @@ export class StargazerProvider {
 
     signatureRequest.metadata = parsedMetadata;
 
-    return window.btoa(JSON.stringify(signatureRequest));
+    const newEncodedSignatureRequest = window.btoa(JSON.stringify(signatureRequest));
+
+    if(newEncodedSignatureRequest !== encodedSignatureRequest){
+      throw new Error('SignatureRequest does not match spec (unable to re-normalize)');
+    }
+
+    return newEncodedSignatureRequest;
   }
 
   signMessage(msg: string) {


### PR DESCRIPTION
### Changes

+ Refactored the `SignatureRequest` external screen.
+ Added new supported method to eth provider `SUPPORTED_WALLET_METHODS.signMessage` and `personal_sign` (as alias).
+ Changed `dag_signMessage` and `eth_signMessage` method params, now we receive an address and a message to sign ([address, signatureRequest]).

### Signature Request
The signature request scheme continues to be the same as in https://github.com/StardustCollective/stargazer-wallet-ext/pull/196, changes were made on checks to the request, the request will not mutate on bad metadata fields but throw an exception.

In terms of the return value, both providers will return the signature hex directly instead of an object (like MetaMask). In the event of an error, they will throw as the other methods.

### Notes
There is some discussion around signing methods for Ethereum providers, there has been numerous methods to sign messages through time like `eth_sign`, `personal_sign`, `signTypedData`, `signTypedData_v1`, `signTypedData_v3`, `signTypedData_v4`. In the future, we will need to stick to a stricter specification for signing messages. For known at least in terms with MetaMask we differ in how we check signature requests and what account ends signing the request, in our case the selected one by the user.
