### PR TITLE
Development/trini/sgw 147/import account bug

### DIFF
--- a/source/scenes/settings/ImportAccount/ImportAccount.native.tsx
+++ b/source/scenes/settings/ImportAccount/ImportAccount.native.tsx
@@ -57,6 +57,7 @@ const ImportAccount: FC<IImportAccountSettings> = ({
             dag4.keyStore
               .decryptPrivateKey(json, data.password)
               .then((privKey: string) => {
+                console.log('handleImportPrivKey....', privKey);
                 handleImportPrivKey(privKey, data.label);
               })
               .catch(() => {
@@ -100,7 +101,7 @@ const ImportAccount: FC<IImportAccountSettings> = ({
     );
   };
 
-  const PrivateKey = React.memo(() => {
+  const renderPrivateKey = () => {
     return (
       <>
         <TextV3.Description color={COLORS_ENUMS.DARK_GRAY} extraStyles={styles.descriptionText}>
@@ -118,9 +119,10 @@ const ImportAccount: FC<IImportAccountSettings> = ({
         />
       </>
     );
-  });
+  };
 
-  const JSONInput = React.memo(() => {
+  const renderJSONInput = () => {
+    // do not memoize as this causes issues in JSON file select
     return (
       <>
         <FileSelect id="importAccount-fileInput" onChange={setJsonFile} disabled={loading} />
@@ -139,7 +141,7 @@ const ImportAccount: FC<IImportAccountSettings> = ({
         />
       </>
     );
-  });
+  };
 
   if (accountName) {
     return (
@@ -186,9 +188,9 @@ const ImportAccount: FC<IImportAccountSettings> = ({
           </View>
         </View>
         {importType === 'priv' ? (
-          <PrivateKey />
+          renderPrivateKey()
         ) : importType === 'json' ? (
-          <JSONInput />
+          renderJSONInput()
         ) : (
           <>
             {hardwareStep === 1 && (

--- a/source/scenes/settings/ImportAccount/styles.ts
+++ b/source/scenes/settings/ImportAccount/styles.ts
@@ -154,7 +154,7 @@ const styles = StyleSheet.create({
   row: {
     height: 33,
   },
-  column_expand: {
+  expand: {
     color: COLORS.gray_light_100,
   },
   svg: {


### PR DESCRIPTION
JSON select in FileSelect was not working because the component kept re-rendering and re-setting the files back to `null`. 
I wrapped the JSONInput and PrivateKeys in React.memo per linter's suggestion, but that actually caused multiple re-renders everytime anything changed in the parent state. Not sure why, but this fixes it. 